### PR TITLE
fix: CIPH-WEB3JSQRL-[1-19]

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -19,4 +19,4 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run actionlint
-        uses: raven-actions/actionlint@v2
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload unit coverage to Codecov
         if: env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ env.CODECOV_TOKEN }}
           files: ./packages/*/.coverage/unit/*.json,./tools/*/.coverage/unit/*.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,14 +176,14 @@ jobs:
           done < dist/released-packages.tsv
 
       - name: Generate SBOM SPDX
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           format: spdx-json
           output-file: dist/sbom-spdx.json
           artifact-name: sbom-spdx.json
 
       - name: Generate SBOM CycloneDX
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
         with:
           format: cyclonedx-json
           output-file: dist/sbom-cyclonedx.json
@@ -253,7 +253,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: ${{ needs.slsa-subjects.outputs.hashes }}
       upload-assets: false

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn run lint
+pnpm run lint

--- a/packages/web3-core/test/unit/__snapshots__/web3_context.test.ts.snap
+++ b/packages/web3-core/test/unit/__snapshots__/web3_context.test.ts.snap
@@ -33,6 +33,7 @@ exports[`Web3Context getContextObject should return correct context object 1`] =
   "provider": HttpProvider {
     "clientUrl": "http://test/abc",
     "httpProviderOptions": undefined,
+    "maxResponseBytes": 10485760,
   },
   "providers": {
     "HttpProvider": [Function],
@@ -53,6 +54,7 @@ exports[`Web3Context getContextObject should return correct context object 1`] =
     "_provider": HttpProvider {
       "clientUrl": "http://test/abc",
       "httpProviderOptions": undefined,
+      "maxResponseBytes": 10485760,
     },
     "useRpcCallSpecification": undefined,
   },
@@ -73,6 +75,7 @@ exports[`Web3Context getContextObject should return correct context object 1`] =
       "_provider": HttpProvider {
         "clientUrl": "http://test/abc",
         "httpProviderOptions": undefined,
+        "maxResponseBytes": 10485760,
       },
       "useRpcCallSpecification": undefined,
     },

--- a/packages/web3-providers-http/src/index.ts
+++ b/packages/web3-providers-http/src/index.ts
@@ -31,17 +31,59 @@ import { HttpProviderOptions } from './types.js';
 
 export { HttpProviderOptions } from './types.js';
 
+const DEFAULT_MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+
 export default class HttpProvider<
 	API extends Web3APISpec = QRLExecutionAPI,
 > extends Web3BaseProvider<API> {
 	private readonly clientUrl: string;
 	private readonly httpProviderOptions: HttpProviderOptions | undefined;
+	private readonly maxResponseBytes: number;
 
 	public constructor(clientUrl: string, httpProviderOptions?: HttpProviderOptions) {
 		super();
 		if (!HttpProvider.validateClientUrl(clientUrl)) throw new InvalidClientError(clientUrl);
+		HttpProvider.warnIfCleartext(clientUrl);
 		this.clientUrl = clientUrl;
 		this.httpProviderOptions = httpProviderOptions;
+		this.maxResponseBytes =
+			httpProviderOptions?.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+	}
+
+	private static warnIfCleartext(clientUrl: string): void {
+		if (!/^http:\/\//i.test(clientUrl)) return;
+		const host = clientUrl.replace(/^http:\/\//i, '').split(/[/?#]/)[0].split(':')[0];
+		const loopbacks = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0']);
+		if (loopbacks.has(host.toLowerCase())) return;
+		// eslint-disable-next-line no-console
+		console.warn(
+			`web3-providers-http: cleartext http:// URL to non-loopback host "${host}". Use https:// for production.`,
+		);
+	}
+
+	private async parseBoundedJson<T>(response: Response): Promise<T> {
+		const contentLength = response.headers.get('content-length') ?? '';
+		if (contentLength) {
+			const declared = Number(contentLength);
+			if (Number.isFinite(declared) && declared > this.maxResponseBytes) {
+				throw new ResponseError(
+					{} as never,
+					`HTTP response exceeds maxResponseBytes (${declared} > ${this.maxResponseBytes})`,
+				);
+			}
+		}
+		const text = await response.text();
+		if (text.length > this.maxResponseBytes) {
+			throw new ResponseError(
+				{} as never,
+				`HTTP response exceeds maxResponseBytes (${text.length} > ${this.maxResponseBytes})`,
+			);
+		}
+		try {
+			return JSON.parse(text) as T;
+		} catch (err) {
+			throw new ResponseError({} as never, `Failed to parse HTTP response: ${String(err)}`);
+		}
 	}
 
 	private static validateClientUrl(clientUrl: string): boolean {
@@ -79,10 +121,14 @@ export default class HttpProvider<
 			body: JSON.stringify(payload),
 		});
 
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-		if (!response.ok) throw new ResponseError(await response.json());
+		if (!response.ok) {
+			throw new ResponseError(
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+				(await this.parseBoundedJson(response)) as never,
+			);
+		}
 
-		return (await response.json()) as JsonRpcResponseWithResult<ResultType>;
+		return this.parseBoundedJson<JsonRpcResponseWithResult<ResultType>>(response);
 	}
 
 	/* eslint-disable class-methods-use-this */

--- a/packages/web3-providers-http/src/types.ts
+++ b/packages/web3-providers-http/src/types.ts
@@ -17,4 +17,5 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 
 export interface HttpProviderOptions {
 	providerOptions: RequestInit;
+	maxResponseBytes?: number;
 }

--- a/packages/web3-providers-ws/package.json
+++ b/packages/web3-providers-ws/package.json
@@ -70,6 +70,6 @@
 		"@theqrl/web3-utils": "^0.4.0",
 		"@types/ws": "8.5.3",
 		"isomorphic-ws": "^5.0.0",
-		"ws": "^8.8.1"
+		"ws": "^8.17.1"
 	}
 }

--- a/packages/web3-providers-ws/src/index.ts
+++ b/packages/web3-providers-ws/src/index.ts
@@ -92,6 +92,18 @@ export default class WebSocketProvider<
 		reconnectOptions?: Partial<ReconnectOptions>,
 	) {
 		super(socketPath, socketOptions, reconnectOptions);
+		WebSocketProvider.warnIfCleartext(socketPath);
+	}
+
+	private static warnIfCleartext(socketPath: string): void {
+		if (!/^ws:\/\//i.test(socketPath)) return;
+		const host = socketPath.replace(/^ws:\/\//i, '').split(/[/?#]/)[0].split(':')[0];
+		const loopbacks = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0']);
+		if (loopbacks.has(host.toLowerCase())) return;
+		// eslint-disable-next-line no-console
+		console.warn(
+			`web3-providers-ws: cleartext ws:// URL to non-loopback host "${host}". Use wss:// for production.`,
+		);
 	}
 
 	public getStatus(): Web3ProviderStatus {
@@ -112,13 +124,16 @@ export default class WebSocketProvider<
 	}
 
 	protected _openSocketConnection() {
-		this._socketConnection = new WebSocket(
-			this._socketPath,
-			undefined,
+		const defaults: ClientOptions = {
+			maxPayload: 10 * 1024 * 1024,
+			perMessageDeflate: false,
+		};
+		const userOptions =
 			this._socketOptions && Object.keys(this._socketOptions).length === 0
 				? undefined
-				: this._socketOptions,
-		);
+				: this._socketOptions;
+		const merged = { ...defaults, ...(userOptions ?? {}) } as ClientOptions;
+		this._socketConnection = new WebSocket(this._socketPath, undefined, merged);
 	}
 
 	protected _closeSocketConnection(code?: number, data?: string) {

--- a/packages/web3-qrl-accounts/src/account.ts
+++ b/packages/web3-qrl-accounts/src/account.ts
@@ -62,6 +62,7 @@ import {
 	qrlSeedFromBytes,
 } from './qrl_wallet.js';
 import { keyStoreSchema } from './schemas.js';
+import { validateArgon2idParams } from './kdf_policy.js';
 import { TransactionFactory } from './tx/transactionFactory.js';
 import type { SignTransactionResult, TypedTransaction, Web3Account, SignResult } from './types.js';
 
@@ -216,9 +217,9 @@ export const signTransaction = async (
 	const validationErrors = signedTx.validate(true);
 
 	if (validationErrors.length > 0) {
-		let errorString = 'Signer Error ';
+		let errorString = 'Signer Error';
 		for (const validationError of validationErrors) {
-			errorString += `${errorString} ${validationError}.`;
+			errorString += ` ${validationError}.`;
 		}
 		throw new TransactionSigningError(errorString);
 	}
@@ -342,6 +343,7 @@ export const encrypt = async (
 			dklen: options?.dklen ?? 32,
 			salt: bytesToHex(salt).replace('0x', ''),
 		};
+		validateArgon2idParams(kdfparams);
 		derivedKey = argon2idSync(
 			uint8ArrayPassword,
 			salt,
@@ -403,10 +405,10 @@ export const encrypt = async (
  */
 export function seedToAccount(seed: Bytes): Web3Account {
 	const acc = newMLDSA87WalletFromExtendedSeed(seed);
+	const seedHex = bytesToHex(acc.getExtendedSeed().toBytes());
 
-	return {
+	const account = {
 		address: toChecksumAddress(acc.getAddressStr()),
-		seed: bytesToHex(acc.getExtendedSeed().toBytes()),
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		signTransaction: (_tx: Transaction) => {
 			throw new TransactionSigningError('Do not have network access to sign the transaction');
@@ -415,7 +417,19 @@ export function seedToAccount(seed: Bytes): Web3Account {
 			sign(typeof data === 'string' ? data : JSON.stringify(data), seed),
 		encrypt: async (password: string, options?: Record<string, unknown>) =>
 			encrypt(acc.getExtendedSeed().toBytes(), password, options),
-	};
+		toJSON() {
+			return { address: account.address, seed: '<redacted>' };
+		},
+	} as unknown as Web3Account;
+
+	Object.defineProperty(account, 'seed', {
+		value: seedHex,
+		enumerable: false,
+		writable: false,
+		configurable: false,
+	});
+
+	return account;
 }
 
 /**
@@ -502,6 +516,7 @@ export const decrypt = async (
 	let derivedKey;
 	if (json.crypto.kdf === 'argon2id') {
 		const { kdfparams } = json.crypto;
+		validateArgon2idParams(kdfparams);
 		const uint8ArraySalt =
 			typeof kdfparams.salt === 'string' ? hexToBytes(kdfparams.salt) : kdfparams.salt;
 		derivedKey = argon2idSync(

--- a/packages/web3-qrl-accounts/src/kdf_policy.ts
+++ b/packages/web3-qrl-accounts/src/kdf_policy.ts
@@ -1,0 +1,59 @@
+/*
+This file is part of web3.js.
+
+web3.js is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+web3.js is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+export const ARGON2ID_BOUNDS = {
+	m: { min: 4096, max: 1_048_576 },
+	t: { min: 2, max: 50 },
+	p: { min: 1, max: 16 },
+	dklen: { min: 16, max: 64 },
+} as const;
+
+const isInt = (v: unknown): v is number =>
+	typeof v === 'number' && Number.isInteger(v) && Number.isFinite(v);
+
+export const validateArgon2idParams = (params: {
+	m: unknown;
+	t: unknown;
+	p: unknown;
+	dklen: unknown;
+}): void => {
+	const { m, t, p, dklen } = params;
+	if (!isInt(m) || m < ARGON2ID_BOUNDS.m.min || m > ARGON2ID_BOUNDS.m.max) {
+		throw new Error(
+			`Argon2id m out of range [${ARGON2ID_BOUNDS.m.min}, ${ARGON2ID_BOUNDS.m.max}]`,
+		);
+	}
+	if (!isInt(t) || t < ARGON2ID_BOUNDS.t.min || t > ARGON2ID_BOUNDS.t.max) {
+		throw new Error(
+			`Argon2id t out of range [${ARGON2ID_BOUNDS.t.min}, ${ARGON2ID_BOUNDS.t.max}]`,
+		);
+	}
+	if (!isInt(p) || p < ARGON2ID_BOUNDS.p.min || p > ARGON2ID_BOUNDS.p.max) {
+		throw new Error(
+			`Argon2id p out of range [${ARGON2ID_BOUNDS.p.min}, ${ARGON2ID_BOUNDS.p.max}]`,
+		);
+	}
+	if (
+		!isInt(dklen) ||
+		dklen < ARGON2ID_BOUNDS.dklen.min ||
+		dklen > ARGON2ID_BOUNDS.dklen.max
+	) {
+		throw new Error(
+			`Argon2id dklen out of range [${ARGON2ID_BOUNDS.dklen.min}, ${ARGON2ID_BOUNDS.dklen.max}]`,
+		);
+	}
+};

--- a/packages/web3-qrl-accounts/test/integration/account.test.ts
+++ b/packages/web3-qrl-accounts/test/integration/account.test.ts
@@ -59,9 +59,12 @@ describe('accounts', () => {
 	describe('seedToAccount', () => {
 		describe('valid cases', () => {
 			it.each(validSeedtoAccountData)('%s', (input, output) => {
-				expect(JSON.stringify(seedToAccount(input.address))).toEqual(
-					JSON.stringify(output),
-				);
+				const account = seedToAccount(input.address);
+				expect(account.address).toEqual(output.address);
+				expect(account.seed).toEqual(output.seed);
+				expect(typeof account.sign).toBe('function');
+				expect(typeof account.signTransaction).toBe('function');
+				expect(typeof account.encrypt).toBe('function');
 			});
 		});
 

--- a/packages/web3-qrl-accounts/test/unit/account.test.ts
+++ b/packages/web3-qrl-accounts/test/unit/account.test.ts
@@ -60,9 +60,19 @@ describe('accounts', () => {
 	describe('seedToAccount', () => {
 		describe('valid cases', () => {
 			it.each(validSeedtoAccountData)('%s', (input, output) => {
-				expect(JSON.stringify(seedToAccount(input.address))).toEqual(
-					JSON.stringify(output),
-				);
+				const account = seedToAccount(input.address);
+				expect(account.address).toEqual(output.address);
+				expect(account.seed).toEqual(output.seed);
+				expect(typeof account.sign).toBe('function');
+				expect(typeof account.signTransaction).toBe('function');
+				expect(typeof account.encrypt).toBe('function');
+			});
+
+			it('should not enumerate seed and should redact JSON.stringify', () => {
+				const account = seedToAccount(validSeedtoAccountData[0][0].address);
+				expect(Object.keys(account)).not.toContain('seed');
+				expect(JSON.stringify(account)).not.toContain(account.seed);
+				expect(JSON.stringify(account)).toContain('<redacted>');
 			});
 		});
 

--- a/packages/web3-qrl-contract/src/contract.ts
+++ b/packages/web3-qrl-contract/src/contract.ts
@@ -79,6 +79,7 @@ import {
 } from '@theqrl/web3-types';
 import { format, isDataFormat, keccak256, toChecksumAddress } from '@theqrl/web3-utils';
 import {
+	isAddressString,
 	isNullish,
 	validator,
 	utils as validatorUtils,
@@ -808,9 +809,14 @@ export class Contract<Abi extends ContractAbi>
 	}
 
 	private _parseAndSetAddress(value?: Address, returnFormat: DataFormat = DEFAULT_RETURN_FORMAT) {
-		this._address = value
-			? toChecksumAddress(format({ format: 'address' }, value, returnFormat))
-			: value;
+		if (isNullish(value) || value === '') {
+			this._address = value;
+			return;
+		}
+		if (typeof value !== 'string' || !isAddressString(value, false)) {
+			throw new Web3ContractError(`Invalid contract address: ${String(value)}`);
+		}
+		this._address = toChecksumAddress(format({ format: 'address' }, value, returnFormat));
 	}
 
 	private _parseAndSetJsonInterface(

--- a/packages/web3-qrl-contract/src/encoding.ts
+++ b/packages/web3-qrl-contract/src/encoding.ts
@@ -16,6 +16,7 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 import { format, isNullish, keccak256 } from '@theqrl/web3-utils';
+import { isAddressString } from '@theqrl/web3-validator';
 
 import {
 	AbiConstructorFragment,
@@ -113,6 +114,11 @@ export const encodeEventABI = (
 	if (!opts.topics.length) delete opts.topics;
 
 	if (address) {
+		if (!isAddressString(address)) {
+			throw new Web3ContractError(
+				`Invalid filter address: ${address}; expected a Q-prefixed QRL address`,
+			);
+		}
 		opts.address = `Q${address.slice(1).toLowerCase()}`;
 	}
 

--- a/packages/web3-qrl-contract/src/log_subscription.ts
+++ b/packages/web3-qrl-contract/src/log_subscription.ts
@@ -141,6 +141,14 @@ export class LogsSubscription extends Web3Subscription<
 	}
 
 	protected formatSubscriptionResult(data: EventLog) {
+		if (
+			!data ||
+			typeof data !== 'object' ||
+			!Array.isArray((data as { topics?: unknown }).topics) ||
+			typeof (data as { data?: unknown }).data !== 'string'
+		) {
+			throw new Error('LogsSubscription received malformed log frame');
+		}
 		return decodeEventABI(this.abi, data as LogsInput, this.jsonInterface, super.returnFormat);
 	}
 }

--- a/packages/web3-qrl-contract/test/unit/contract.test.ts
+++ b/packages/web3-qrl-contract/test/unit/contract.test.ts
@@ -128,7 +128,7 @@ describe('Contract', () => {
 			});
 
 			// eslint-disable-next-line jest/no-standalone-expect
-			expect(contract.provider).toEqual({
+			expect(contract.provider).toMatchObject({
 				clientUrl: provider,
 				httpProviderOptions: undefined,
 			});
@@ -147,7 +147,7 @@ describe('Contract', () => {
 			);
 
 			// eslint-disable-next-line jest/no-standalone-expect
-			expect(contract.provider).toEqual({
+			expect(contract.provider).toMatchObject({
 				clientUrl: provider,
 				httpProviderOptions: undefined,
 			});

--- a/packages/web3-qrl-qrns/src/index.ts
+++ b/packages/web3-qrl-qrns/src/index.ts
@@ -25,4 +25,5 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 import { registryAddresses } from './config.js';
 
 export * from './qrns.js';
+export { normalize, normalizeWithSource, namehash } from './utils.js';
 export { registryAddresses };

--- a/packages/web3-qrl-qrns/src/registry.ts
+++ b/packages/web3-qrl-qrns/src/registry.ts
@@ -18,10 +18,14 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 import { Web3ContextObject } from '@theqrl/web3-core';
 import { Contract } from '@theqrl/web3-qrl-contract';
 import { Address } from '@theqrl/web3-types';
+import { isAddressString } from '@theqrl/web3-validator';
 import { QRNSRegistryAbi } from './abi/qrns/QRNSRegistry.js';
 import { PublicResolverAbi } from './abi/qrns/PublicResolver.js';
 import { registryAddresses } from './config.js';
 import { namehash } from './utils.js';
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const QRL_ZERO_ADDRESS = 'Q0000000000000000000000000000000000000000';
 
 export class Registry {
 	private readonly contract: Contract<typeof QRNSRegistryAbi>;
@@ -71,13 +75,22 @@ export class Registry {
 				.resolver(namehash(name))
 				.call()
 				.then(address => {
-					// address type is unknown, not sure why
-					if (typeof address === 'string') {
-						const contract = new Contract(PublicResolverAbi, address, this.context);
-						// TODO: set contract provider needs to be added when qrns current provider
-						return contract;
+					if (typeof address !== 'string') {
+						throw new Error('QRNS registry returned non-string resolver address');
 					}
-					throw new Error();
+					if (!isAddressString(address)) {
+						throw new Error(
+							`QRNS registry returned invalid resolver address: ${address}`,
+						);
+					}
+					const lower = address.toLowerCase();
+					if (
+						lower === ZERO_ADDRESS.toLowerCase() ||
+						lower === QRL_ZERO_ADDRESS.toLowerCase()
+					) {
+						throw new Error('QRNS registry returned zero resolver address');
+					}
+					return new Contract(PublicResolverAbi, address, this.context);
 				});
 		} catch (error) {
 			throw new Error(); // TODO: TransactionRevertInstructionError Needs to be added after web3-qrl call method is implemented

--- a/packages/web3-qrl-qrns/src/utils.ts
+++ b/packages/web3-qrl-qrns/src/utils.ts
@@ -21,6 +21,13 @@ import { ens_normalize } from '@adraffy/ens-normalize';
 
 export const normalize = (name: string) => ens_normalize(name);
 
+// Returns both the input and the normalised form so callers can display the
+// canonical name for confirmation (homoglyph defence).
+export const normalizeWithSource = (name: string): { input: string; normalized: string } => ({
+	input: name,
+	normalized: ens_normalize(name),
+});
+
 export const namehash = (inputName: string) => {
 	// Reject empty names:
 	let node = '';

--- a/packages/web3-qrl-qrns/test/unit/registry.test.ts
+++ b/packages/web3-qrl-qrns/test/unit/registry.test.ts
@@ -24,6 +24,7 @@ describe('registry', () => {
 	let object: Web3ContextObject;
 	let registry: Registry;
 	const mockAddress = 'Q0000000000000000000000000000000000000000';
+	const mockResolverAddress = 'Q1234567890123456789012345678901234567890';
 	const QRNS_NAME = 'web3js.qrl';
 
 	beforeAll(() => {
@@ -147,12 +148,12 @@ describe('registry', () => {
 				.spyOn(
 					{
 						call: async () => {
-							return mockAddress;
+							return mockResolverAddress;
 						},
 					},
 					'call',
 				)
-				.mockReturnValue(Promise.resolve(mockAddress));
+				.mockReturnValue(Promise.resolve(mockResolverAddress));
 
 			const resolverMock = jest
 				.spyOn(registry['contract'].methods, 'resolver')
@@ -186,7 +187,7 @@ describe('registry', () => {
 
 			await expect(async () => {
 				await registry.getResolver(QRNS_NAME);
-			}).rejects.toThrow(new Error());
+			}).rejects.toThrow('non-string resolver address');
 			expect(resolverMock).toHaveBeenCalledWith(namehash(QRNS_NAME));
 			expect(call).toHaveBeenCalled();
 		});

--- a/packages/web3-qrl/src/utils/get_transaction_gas_pricing.ts
+++ b/packages/web3-qrl/src/utils/get_transaction_gas_pricing.ts
@@ -33,6 +33,23 @@ import { InternalTransaction } from '../types.js';
 // eslint-disable-next-line import/no-cycle
 import { getTransactionType } from './transaction_builder.js';
 
+// 256-bit unsigned upper bound; on-chain fee fields are uint256.
+const MAX_UINT256 = (BigInt(1) << BigInt(256)) - BigInt(1);
+
+const safeBigInt = (value: Numbers | undefined, label: string): bigint => {
+	if (isNullish(value)) {
+		throw new Error(`Expected numeric ${label}, got ${String(value)}`);
+	}
+	if (typeof value === 'string' && value.startsWith('-')) {
+		throw new Error(`Negative ${label} from RPC: ${value}`);
+	}
+	const result = BigInt(value);
+	if (result < BigInt(0) || result > MAX_UINT256) {
+		throw new Error(`${label} out of uint256 range: ${result.toString()}`);
+	}
+	return result;
+};
+
 async function getEip1559GasPricing<ReturnFormat extends DataFormat>(
 	transaction: FormatType<Transaction, typeof QRL_DATA_FORMAT>,
 	web3Context: Web3Context<QRLExecutionAPI>,
@@ -40,19 +57,21 @@ async function getEip1559GasPricing<ReturnFormat extends DataFormat>(
 ): Promise<FormatType<{ maxPriorityFeePerGas?: Numbers; maxFeePerGas?: Numbers }, ReturnFormat>> {
 	const block = await getBlock(web3Context, web3Context.defaultBlock, false, returnFormat);
 
+	const baseFeePerGas = safeBigInt(block.baseFeePerGas as Numbers, 'block.baseFeePerGas');
+	const maxPriorityFeePerGas = safeBigInt(
+		(transaction.maxPriorityFeePerGas ?? web3Context.defaultMaxPriorityFeePerGas) as Numbers,
+		'maxPriorityFeePerGas',
+	);
+
 	return {
 		maxPriorityFeePerGas: format(
 			{ format: 'uint' },
-			transaction.maxPriorityFeePerGas ?? web3Context.defaultMaxPriorityFeePerGas,
+			maxPriorityFeePerGas as Numbers,
 			returnFormat,
 		),
 		maxFeePerGas: format(
 			{ format: 'uint' },
-			(transaction.maxFeePerGas ??
-				BigInt(block.baseFeePerGas) * BigInt(2) +
-					BigInt(
-						transaction.maxPriorityFeePerGas ?? web3Context.defaultMaxPriorityFeePerGas,
-					)) as Numbers,
+			(transaction.maxFeePerGas ?? baseFeePerGas * BigInt(2) + maxPriorityFeePerGas) as Numbers,
 			returnFormat,
 		),
 	};

--- a/packages/web3-qrl/src/utils/watch_transaction_by_subscription.ts
+++ b/packages/web3-qrl/src/utils/watch_transaction_by_subscription.ts
@@ -16,11 +16,27 @@ along with web3.js.  If not, see <http://www.gnu.org/licenses/>.
 */
 import { Bytes, Numbers, BlockHeaderOutput, TransactionReceipt } from '@theqrl/web3-types';
 import { format } from '@theqrl/web3-utils';
+import { isHexStrict } from '@theqrl/web3-validator';
 
 import { DataFormat } from '@theqrl/web3-types';
 import { NewHeadsSubscription } from '../web3_subscriptions.js';
 import { transactionReceiptSchema } from '../schemas.js';
 import { WaitProps, watchTransactionByPolling } from './watch_transaction_by_pooling.js';
+
+const isValidUnsignedHexNumber = (value: unknown): value is string | number | bigint => {
+	if (typeof value === 'bigint' || typeof value === 'number') {
+		return value >= 0;
+	}
+	if (typeof value !== 'string') {
+		return false;
+	}
+	if (value.startsWith('-')) return false;
+	if (!isHexStrict(value)) return false;
+	return true;
+};
+
+const isValidBlockHash = (value: unknown): value is string =>
+	typeof value === 'string' && /^0x[0-9a-fA-F]{64}$/.test(value);
 
 /**
  * This function watches a Transaction by subscribing to new heads.
@@ -47,6 +63,8 @@ export const watchTransactionBySubscription = <
 					needToWatchLater = false;
 					if (
 						!newBlockHeader?.number ||
+						!isValidUnsignedHexNumber(newBlockHeader.number) ||
+						!isValidBlockHash(newBlockHeader.parentHash) ||
 						// For some cases, the on-data event is fired couple times for the same block!
 						// This needs investigation but seems to be because of multiple `subscription.on('data'...)` even this should not cause that.
 						lastCaughtBlockHash === newBlockHeader?.parentHash

--- a/packages/web3-utils/src/chunk_response_parser.ts
+++ b/packages/web3-utils/src/chunk_response_parser.ts
@@ -18,6 +18,8 @@ import { JsonRpcResponse } from '@theqrl/web3-types';
 import { InvalidResponseError } from '@theqrl/web3-errors';
 import { EventEmitter } from 'events';
 
+const MAX_CHUNK_BYTES = 10 * 1024 * 1024;
+
 export class ChunkResponseParser {
 	private lastChunk: string | undefined;
 	private lastChunkTimeout: NodeJS.Timeout | undefined;
@@ -58,6 +60,20 @@ export class ChunkResponseParser {
 			}
 
 			let result;
+
+			if (chunkData.length > MAX_CHUNK_BYTES) {
+				this.lastChunk = undefined;
+				this.clearQueues();
+				this.eventEmitter.emit(
+					'error',
+					new InvalidResponseError({
+						id: 1,
+						jsonrpc: '2.0',
+						error: { code: 2, message: 'Chunk size exceeds maximum' },
+					}),
+				);
+				return;
+			}
 
 			try {
 				result = JSON.parse(chunkData) as unknown as JsonRpcResponse;

--- a/packages/web3-utils/src/objects.ts
+++ b/packages/web3-utils/src/objects.ts
@@ -32,26 +32,31 @@ const isIterable = (item: unknown): item is Record<string, unknown> =>
  * @param sources - An array of source objects.
  * @returns - The merged object.
  */
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 export const mergeDeep = (
 	destination: Record<string, unknown>,
 	...sources: Record<string, unknown>[]
 ): Record<string, unknown> => {
-	const result = destination; // clone deep here
-	if (!isIterable(result)) {
-		return result;
+	if (!isIterable(destination)) {
+		return destination;
 	}
+	const result = { ...destination };
 	for (const src of sources) {
 		// eslint-disable-next-line no-restricted-syntax
 		for (const key in src) {
+			if (FORBIDDEN_KEYS.has(key) || !Object.hasOwnProperty.call(src, key)) {
+				continue;
+			}
 			if (isIterable(src[key])) {
 				if (!result[key]) {
 					result[key] = {};
 				}
-				mergeDeep(
+				result[key] = mergeDeep(
 					result[key] as Record<string, unknown>,
-					src[key],
+					src[key] as Record<string, unknown>,
 				);
-			} else if (!isNullish(src[key]) && Object.hasOwnProperty.call(src, key)) {
+			} else if (!isNullish(src[key])) {
 				if (Array.isArray(src[key]) || src[key] instanceof TypedArray) {
 					// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
 					result[key] = (src[key] as unknown[]).slice(0);

--- a/packages/web3-utils/src/socket_provider.ts
+++ b/packages/web3-utils/src/socket_provider.ts
@@ -377,11 +377,16 @@ export abstract class SocketProvider<
 
 		if (this._reconnectAttempts < this._reconnectOptions.maxAttempts) {
 			this._reconnectAttempts += 1;
+			const base = this._reconnectOptions.delay;
+			const exp = base * 2 ** (this._reconnectAttempts - 1);
+			const capped = Math.min(exp, 60_000);
+			const jitter = capped * (Math.random() * 0.4 - 0.2);
+			const wait = Math.max(0, Math.floor(capped + jitter));
 			setTimeout(() => {
 				this._removeSocketListeners();
 				this.connect();
 				this.isReconnecting = false;
-			}, this._reconnectOptions.delay);
+			}, wait);
 		} else {
 			this.isReconnecting = false;
 			this._clearQueues();
@@ -478,7 +483,7 @@ export abstract class SocketProvider<
 				(response as JsonRpcNotification).method.endsWith('_subscription')
 			) {
 				this._eventEmitter.emit('message', response);
-				return;
+				continue;
 			}
 
 			const requestId = jsonRpc.isBatchResponse(response)
@@ -488,7 +493,7 @@ export abstract class SocketProvider<
 			const requestItem = this._sentRequestsQueue.get(requestId);
 
 			if (!requestItem) {
-				return;
+				continue;
 			}
 
 			if (

--- a/packages/web3-utils/test/unit/objects.test.ts
+++ b/packages/web3-utils/test/unit/objects.test.ts
@@ -21,9 +21,22 @@ import { mergeDeepData } from '../fixtures/objects';
 describe('objects', () => {
 	describe('mergeDeep', () => {
 		it.each(mergeDeepData)('$message', ({ destination, sources, output }) => {
-			mergeDeep(destination, ...sources);
+			const result = mergeDeep(destination, ...sources);
 
-			expect(destination).toEqual(output);
+			expect(result).toEqual(output);
+		});
+
+		it('should not pollute Object.prototype via __proto__', () => {
+			const untrusted = JSON.parse('{"__proto__":{"polluted":"yes"}}');
+			const result = mergeDeep({}, untrusted) as Record<string, unknown>;
+			expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+			expect(result.polluted).toBeUndefined();
+		});
+
+		it('should ignore constructor and prototype keys', () => {
+			const untrusted = { constructor: { polluted: 'yes' }, prototype: { polluted: 'yes' } };
+			mergeDeep({}, untrusted);
+			expect(({} as Record<string, unknown>).polluted).toBeUndefined();
 		});
 
 		it('should not mutate the sources', () => {

--- a/packages/web3-validator/src/utils.ts
+++ b/packages/web3-validator/src/utils.ts
@@ -65,7 +65,7 @@ export const parseBaseType = <T = typeof VALID_QRL_BASE_TYPES[number]>(
 		baseTypeSize = parseInt(strippedType.substring(3), 10);
 		strippedType = 'int';
 	} else if (strippedType.startsWith('uint')) {
-		baseTypeSize = parseInt(type.substring(4), 10);
+		baseTypeSize = parseInt(strippedType.substring(4), 10);
 		strippedType = 'uint';
 	} else if (strippedType.startsWith('bytes')) {
 		baseTypeSize = parseInt(strippedType.substring(5), 10);
@@ -75,6 +75,39 @@ export const parseBaseType = <T = typeof VALID_QRL_BASE_TYPES[number]>(
 	}
 
 	return { baseType: strippedType as unknown as T, isArray, baseTypeSize, arraySizes };
+};
+
+const assertSupportedSize = (
+	type: string,
+	baseType: string | undefined,
+	baseTypeSize: number | undefined,
+): void => {
+	if (baseTypeSize === undefined || Number.isNaN(baseTypeSize)) return;
+	if (
+		(baseType === 'int' || baseType === 'uint') &&
+		(baseTypeSize <= 0 || baseTypeSize > 256 || baseTypeSize % 8 !== 0)
+	) {
+		throw new Web3ValidatorError([
+			{
+				keyword: 'eth',
+				message: `Eth data type "${type}" is not valid: unsupported ${baseType} size`,
+				params: { eth: type },
+				instancePath: '',
+				schemaPath: '',
+			},
+		]);
+	}
+	if (baseType === 'bytes' && (baseTypeSize <= 0 || baseTypeSize > 32)) {
+		throw new Web3ValidatorError([
+			{
+				keyword: 'eth',
+				message: `Eth data type "${type}" is not valid: unsupported bytes size`,
+				params: { eth: type },
+				instancePath: '',
+				schemaPath: '',
+			},
+		]);
+	}
 };
 
 const convertEthType = (
@@ -96,6 +129,7 @@ const convertEthType = (
 	}
 
 	const { baseType, baseTypeSize } = parseBaseType(type);
+	assertSupportedSize(type, baseType as string | undefined, baseTypeSize);
 
 	if (!baseType && !extraTypes.includes(type)) {
 		throw new Web3ValidatorError([
@@ -143,7 +177,7 @@ export const abiSchemaToJsonSchema = (
 		// e.g. {name: 'a', type: 'uint'}
 		if (isAbiParameterSchema(abi)) {
 			abiType = abi.type;
-			abiName = abi.name;
+			abiName = abi.name || `${level}/${index}`;
 			abiComponents = abi.components as FullValidationSchema;
 			// If its short form string value e.g. ['uint']
 		} else if (typeof abi === 'string') {

--- a/packages/web3/src/accounts.ts
+++ b/packages/web3/src/accounts.ts
@@ -53,14 +53,29 @@ export const initAccountsForContext = (context: Web3Context<QRLExecutionAPI>) =>
 		return signTransaction(tx, seedBytes);
 	};
 
+	const wrapAccount = <S extends (transaction: Transaction) => unknown>(
+		account: ReturnType<typeof seedToAccount>,
+		signTx: S,
+	) => {
+		const wrapper = { ...account, signTransaction: signTx };
+		Object.defineProperty(wrapper, 'seed', {
+			value: account.seed,
+			enumerable: false,
+			writable: false,
+			configurable: false,
+		});
+		Object.defineProperty(wrapper, 'toJSON', {
+			value: () => ({ address: wrapper.address, seed: '<redacted>' }),
+			enumerable: false,
+		});
+		return wrapper;
+	};
+
 	const seedToAccountWithContext = (seed: Uint8Array | string) => {
 		const account = seedToAccount(seed);
-
-		return {
-			...account,
-			signTransaction: async (transaction: Transaction) =>
-				signTransactionWithContext(transaction, account.seed),
-		};
+		return wrapAccount(account, async (transaction: Transaction) =>
+			signTransactionWithContext(transaction, account.seed),
+		);
 	};
 
 	const decryptWithContext = async (
@@ -69,22 +84,16 @@ export const initAccountsForContext = (context: Web3Context<QRLExecutionAPI>) =>
 		options?: Record<string, unknown>,
 	) => {
 		const account = await decrypt(keystore, password, (options?.nonStrict as boolean) ?? true);
-
-		return {
-			...account,
-			signTransaction: async (transaction: Transaction) =>
-				signTransactionWithContext(transaction, account.seed),
-		};
+		return wrapAccount(account, async (transaction: Transaction) =>
+			signTransactionWithContext(transaction, account.seed),
+		);
 	};
 
 	const createWithContext = () => {
 		const account = create();
-
-		return {
-			...account,
-			signTransaction: async (transaction: Transaction) =>
-				signTransactionWithContext(transaction, account.seed),
-		};
+		return wrapAccount(account, async (transaction: Transaction) =>
+			signTransactionWithContext(transaction, account.seed),
+		);
 	};
 
 	const wallet = new Wallet({

--- a/packages/web3/test/unit/web3.test.ts
+++ b/packages/web3/test/unit/web3.test.ts
@@ -27,7 +27,7 @@ describe('Web3 object', () => {
 
 		const web3 = new Web3('http://somenode');
 		expect(web3).toBeTruthy();
-		expect(web3.provider).toEqual({
+		expect(web3.provider).toMatchObject({
 			clientUrl: 'http://somenode',
 			httpProviderOptions: undefined,
 		});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -659,7 +659,7 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(ws@8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ws:
-        specifier: ^8.8.1
+        specifier: ^8.17.1
         version: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     devDependencies:
       '@theqrl/eslint-config-base-web3':


### PR DESCRIPTION
CIPH-WEB3JSQRL-1 | Prototype pollution in mergeDeep (CVE-2024-21505 unpatched)
CIPH-WEB3JSQRL-2 | Plaintext extended seed exported on Web3Account object
CIPH-WEB3JSQRL-3 | ws package floor lags upstream patch (CVE-2024-37890)
CIPH-WEB3JSQRL-4 | ABI-validator hardening cluster missing from upstream
CIPH-WEB3JSQRL-5 | Argon2id KDF parameters unvalidated on encrypt and decrypt
CIPH-WEB3JSQRL-6 | WebSocket provider has no payload cap; permessage-deflate enabled
CIPH-WEB3JSQRL-7 | HTTP provider does not bound response size before JSON.parse
CIPH-WEB3JSQRL-8 | QRNS resolver accepts unvalidated address from registry
CIPH-WEB3JSQRL-9 | Block-header values from RPC fed into BigInt arithmetic without bounds
CIPH-WEB3JSQRL-10 | Exponential error-string concatenation in signTransaction
CIPH-WEB3JSQRL-11 | WS reconnect lacks exponential backoff and jitter
CIPH-WEB3JSQRL-12 | Socket-provider _onMessage uses return instead of continue
CIPH-WEB3JSQRL-13 | Event-log decoder trusts RPC frame without runtime schema check
CIPH-WEB3JSQRL-14 | encodeEventABI rewrites address as Q${address.slice(1)} without validation
CIPH-WEB3JSQRL-15 | QRNS name normalisation result not surfaced to the user (homoglyph)
CIPH-WEB3JSQRL-16 | HTTP / WebSocket providers permit cleartext URLs without warning
CIPH-WEB3JSQRL-17 | _parseAndSetAddress defers validation to format()
CIPH-WEB3JSQRL-18 | Third-party GitHub Actions pinned to mutable tags
CIPH-WEB3JSQRL-19 | Husky pre-push hook calls yarn in a pnpm-managed repo